### PR TITLE
Set TMPDIR=/var/tmp to store lockfiles.

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=xdg-config/kdeglobals:ro # gives application access to kdeglobals
   - --talk-name=com.canonical.AppMenu.Registrar # gives application access to dbus menu
   - --share=network # required for LanguageTool
+  - --env=TMPDIR=/var/tmp # for lockfiles
   - --env=PATH=/usr/bin:/app/bin:/app/bin/x86_64-linux
   - --env=TEXMFCACHE=$XDG_CACHE_HOME
   - --env=LC_ALL=C # works around LuaLaTex issue with locale


### PR DESCRIPTION
Texstudio uses a lockfile to maintain a single running instance. Setting TMPDIR to /var/tmp ensures that all instances of the application can see this lockfile.