### PR TITLE
Use the new openjpeg shared module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -37,12 +37,7 @@ modules:
   build-commands:
     - /usr/lib/sdk/openjdk11/install.sh
 
-- name: openjpeg # build dependency of poppler
-  buildsystem: cmake-ninja
-  sources:
-    - type: archive
-      url: https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz
-      sha256: 63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9
+- shared-modules/openjpeg/openjpeg.json
 
 - name: poppler # build dependency of TeXstudio
   buildsystem: cmake-ninja


### PR DESCRIPTION
In addition to the long term benefit of a shared maintenance, this also
brings a couple of immediate wins: the cmake/cleanup config should
result in a slightly faster and smaller build.