### PR TITLE
remove --filesystem=xdg-config/kdeglobals:ro

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -15,7 +15,6 @@ finish-args:
   - --share=ipc
   - --device=dri
   - --filesystem=host # lets LuaLaTeX etc. write output files, even if the document is stored outside of ~
-  - --filesystem=xdg-config/kdeglobals:ro # gives application access to kdeglobals
   - --talk-name=com.canonical.AppMenu.Registrar # gives application access to dbus menu
   - --share=network # required for LanguageTool
   - --env=TMPDIR=/var/tmp # for lockfiles


### PR DESCRIPTION
not needed since KDE runtime 5.12