### PR TITLE
Provide library paths for Perl

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -23,6 +23,8 @@ finish-args:
   - --talk-name=com.canonical.AppMenu.Registrar # required for global menu
   - --share=network # required for LanguageTool
   - --env=PATH=/usr/bin:/app/bin:/app/texlive/bin:/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux # add paths of TeXlive Flatpak extension binaries
+  - --env=PERL5LIB=/app/texlive/lib/perl5/site_perl/5.34.0/:/app/texlive/lib/perl5/5.34.0/ # add include paths for Perl @INC variable
+  - --env=LD_LIBRARY_PATH=/app/texlive/lib/:/app/texlive/lib/perl5/5.34.0/x86_64-linux/CORE/:/app/texlive/lib/perl5/5.34.0/aarch64-linux/CORE/ # add library paths
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
The biblatex processor Biber needs Perl, but Perl cannot find its
libperl.so and other Perl modules like strict.pm. Add environment
variables with the right paths under /app/texlive for x86_64 and
aarch64 (ARM64 like Raspberry Pi 3 and newer).

Fixes: https://github.com/flathub/org.texstudio.TeXstudio/issues/94
       epstopdf results in perl error