### PR TITLE
Add extension point for ngram data

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -11,6 +11,11 @@ add-extensions:
     autodelete: true
     version: '22.08'
     no-autodownload: true
+  org.texstudio.TeXstudio.Extension.ngrams:
+    directory: ngrams
+    subdirectories: true
+    autodelete: true
+    no-autodownload: true
 command: texstudio.sh
 rename-icon: texstudio
 rename-appdata-file: texstudio.metainfo.xml
@@ -32,11 +37,11 @@ cleanup:
   - /lib/pkgconfig
   - /share/man
 modules:
-  - name: texlive-extension
+  - name: extension-points
     buildsystem: simple
     build-commands:
       - mkdir /app/texlive
-
+      - mkdir ${FLATPAK_DEST}/ngrams
   - name: boost # build dependency of poppler
     buildsystem: simple
     build-commands:

--- a/texstudio.sh
+++ b/texstudio.sh
@@ -18,4 +18,4 @@ fi
 # https://github.com/languagetool-org/languagetool
 # make sure to kill java so we don't end up with lots of unused LanguageTool server instances
 # https://stackoverflow.com/questions/6674327/redirect-all-output-to-file-in-bash
-/app/jre/bin/java -cp /app/languagetool/languagetool-server.jar org.languagetool.server.HTTPServer --port 8081 --allow-origin > /dev/null 2>&1 & texstudio "$@" && pkill -SIGKILL java
+/app/jre/bin/java -cp /app/languagetool/languagetool-server.jar org.languagetool.server.HTTPServer --port 8081 --allow-origin --languageModel /app/ngrams > /dev/null 2>&1 & texstudio "$@" && pkill -SIGKILL java


### PR DESCRIPTION
LanguageTool needs extra ngram data files. This adds an extension point so that we can optionally install these as a flatpak extension.

Related issue: #142 