### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -26,7 +26,7 @@ finish-args:
   - --share=ipc
   - --share=network # required for template repository. Does not interfere with LanguageTool, which is now accessible on the host as well
   - --device=dri
-  # filesystem access: required to open files, until native filechooser portal is implemented
+  # filesystem access: required e.g. for \include, \input or \includegraphics
   - --filesystem=home
   - --filesystem=/media
   - --filesystem=/mnt

--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -26,7 +26,13 @@ finish-args:
   - --share=ipc
   - --share=network # required for template repository. Does not interfere with LanguageTool, which is now accessible on the host as well
   - --device=dri
-  - --filesystem=host # required to open files
+  # filesystem access: required to open files, until native filechooser portal is implemented
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=/var/run/media
+  - --filesystem=/var/mnt
   - --filesystem=/tmp # this way lualatex etc. can access files newly ceated by TeXstudio stored in the hosts's /tmp
   - --talk-name=org.freedesktop.Flatpak # required for flatpak-spawn --host
   - --talk-name=com.canonical.AppMenu.Registrar # required for global menu


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt