### PR TITLE
Downgrade org.freedesktop.Sdk.Extension.texlive to 22.08

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -9,7 +9,7 @@ add-extensions:
     directory: texlive
     subdirectories: true
     autodelete: true
-    version: '23.08'
+    version: '22.08'
     no-autodownload: true
   org.texstudio.TeXstudio.Extension.ngrams:
     directory: ngrams


### PR DESCRIPTION
This reverts commit 5e6468acefed843429f59f0f8a5db050f9028928 and addresses issues caused by the TeX Live extension upgrade in #172, particularly [in this comment](https://github.com/flathub/org.texstudio.TeXstudio/issues/172#issuecomment-1762037519) by @jakobjakobson13 (sorry for the ping):

> You are right, pdflatex/xelatex/lualatex are not working.
> 
> I´m not sure about the reason but that´s what I found so far:
> 
>     * texworks and texmaker are using the texlive 22.08 extension and are working
> 
>     * texstudio uses the texlive 23.08 extension and is not working
> 
> 
> I found a [bug](https://github.com/flathub/com.github.xournalpp.xournalpp/pull/86) describing the same issue stating it is due "outdated" gnome extension. [Qt6.5](https://invent.kde.org/packaging/flatpak-kde-runtime/-/blob/qt6.5/org.kde.Sdk.json.in?ref_type=heads) is based on the freedesktop extension 22.08 and therefore does not ship GLIB_2.38 which was released after the release of the freedesktop extension 22.08. So by following this argumentation you either have to
> 
>     * wait for the QT6.6 extension (which I did not find (yet?) in the kde repository)
> 
>     * switch to qt5.15-23.08 (which is in the kde repository but I could not find any announcement and none of the kde apps is using it, so it might not be released yet)
>       This in agreement with the `libc.so.6` libraries in all three editors being built with GNU libc 2.35.
> 
> 
> So as long as the kde extension is not updated, I see no other way than downgrading the texlive extension again till the release of a newer kde extension.

