### PR TITLE
Revert "poppler: Update poppler-25.08.0.tar.xz to 25.09.0 (#252)"

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -58,8 +58,8 @@ modules:
       - -DENABLE_LIBCURL=OFF
     sources:
       - type: archive
-        url: https://poppler.freedesktop.org/poppler-25.09.0.tar.xz
-        sha256: 758abfe0c77108c72d654b291dfbce54964b5315a53028e3875f07ef55ff20a3
+        url: https://poppler.freedesktop.org/poppler-25.08.0.tar.xz
+        sha256: 425ed4d4515a093bdcdbbaac6876f20617451edc710df6a4fd6c45dd67eb418d
         x-checker-data:
           type: anitya
           project-id: 3686


### PR DESCRIPTION
This reverts commit 7b1b7e6a088b07cecf3d998c851b5df9c01fef1f.
fix #253 