### PR TITLE
fix `poppler` module, `texstudio` module from git

### DIFF
--- a/org.texstudio.TeXstudio.yaml
+++ b/org.texstudio.TeXstudio.yaml
@@ -56,10 +56,11 @@ modules:
       - -DENABLE_GLIB=OFF
       - -DENABLE_QT5=OFF
       - -DENABLE_LIBCURL=OFF
+      - -DENABLE_GPGME=OFF
     sources:
       - type: archive
-        url: https://poppler.freedesktop.org/poppler-25.08.0.tar.xz
-        sha256: 425ed4d4515a093bdcdbbaac6876f20617451edc710df6a4fd6c45dd67eb418d
+        url: https://poppler.freedesktop.org/poppler-25.09.0.tar.xz
+        sha256: 758abfe0c77108c72d654b291dfbce54964b5315a53028e3875f07ef55ff20a3
         x-checker-data:
           type: anitya
           project-id: 3686


### PR DESCRIPTION
Fix the following error message when building:

```
fatal: not a git repository (or any parent up to mount point /work/.flatpak-builder/build)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository (or any parent up to mount point /work/.flatpak-builder/build)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository (or any parent up to mount point /work/.flatpak-builder/build)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```